### PR TITLE
Update README with (mostly st) caveats

### DIFF
--- a/README
+++ b/README
@@ -64,3 +64,12 @@ usage
 pap u|use <palette>    Use selected palette
 pap l|list             List available palettes
 pap r|reload           Reload active palette (e.g. in $SHELL's startup file)
+
+
+caveats
+-------
+
+Make sure that your terminal emulator has proper OSC implementation.
+For example, st terminal doesn't play nicely with pap without the osc patch:
+
+https://st.suckless.org/patches/osc_10_11_12_2/


### PR DESCRIPTION
pap causes st to crash on launch without the [osc](https://st.suckless.org/patches/osc_10_11_12_2/) patch.
I'm assuming that would be something worth mentioning in README.

In addition, I also had my st patched with [xresources](https://st.suckless.org/patches/xresources/) patch which increased the "flash" on launch. After removing it, flash is (almost) unnoticeable. I wan't sure if this info should also be included in README, so I'm just mentioning it here.
Less invasive way (without unpatching xresources) would be removing the colors assignment part from `config.h`, like so:

```diff
-		{ "color0",       STRING,  &colorname[0] },
-		{ "color1",       STRING,  &colorname[1] },
-		{ "color2",       STRING,  &colorname[2] },
-		{ "color3",       STRING,  &colorname[3] },
-		{ "color4",       STRING,  &colorname[4] },
-		{ "color5",       STRING,  &colorname[5] },
-		{ "color6",       STRING,  &colorname[6] },
-		{ "color7",       STRING,  &colorname[7] },
-		{ "color8",       STRING,  &colorname[8] },
-		{ "color9",       STRING,  &colorname[9] },
-		{ "color10",      STRING,  &colorname[10] },
-		{ "color11",      STRING,  &colorname[11] },
-		{ "color12",      STRING,  &colorname[12] },
-		{ "color13",      STRING,  &colorname[13] },
-		{ "color14",      STRING,  &colorname[14] },
-		{ "color15",      STRING,  &colorname[15] },
-		{ "background",   STRING,  &colorname[256] },
-		{ "foreground",   STRING,  &colorname[257] },
-		{ "cursorColor",  STRING,  &colorname[258] },
```